### PR TITLE
Query question ids instead of whole questions during quiz creation

### DIFF
--- a/src/main/java/ua/max/quizbot/repositories/QuestionRepository.java
+++ b/src/main/java/ua/max/quizbot/repositories/QuestionRepository.java
@@ -1,9 +1,14 @@
 package ua.max.quizbot.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ua.max.quizbot.models.Question;
 
+import java.util.List;
+
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    @Query("SELECT q.questionId FROM Question q")
+    List<Long> findAllIds();
 }

--- a/src/main/java/ua/max/quizbot/services/QuizService.java
+++ b/src/main/java/ua/max/quizbot/services/QuizService.java
@@ -39,9 +39,9 @@ public class QuizService {
 
     @Transactional
     public Quiz createQuiz(Session session) {
-        List<Question> allQuestions = questionRepository.findAll();
+        List<Long> allQuestionsIds = questionRepository.findAllIds();
 
-        if (QUIZ_LENGTH < 1 || QUIZ_LENGTH > allQuestions.size()){
+        if (QUIZ_LENGTH < 1 || QUIZ_LENGTH > allQuestionsIds.size()){
             throw new RuntimeException("Invalid quiz length");
         }
 
@@ -49,8 +49,10 @@ public class QuizService {
         quizRepository.save(newQuiz);
 
         newQuiz.setSession(session);
-        Collections.shuffle(allQuestions);
-        List<Question> questions = allQuestions.subList(0, QUIZ_LENGTH);
+
+        Collections.shuffle(allQuestionsIds);
+        List<Question> questions = allQuestionsIds.subList(0, QUIZ_LENGTH).stream()
+                .map(questionRepository::getReferenceById).toList();
 
         List<QuizExercise> newQuizExercises = questions.stream()
                 .map(question -> quizExerciseService.createQuizExercise(newQuiz, question, questions.indexOf(question)))


### PR DESCRIPTION
In order to optimize time (in particular once the question table will be bigger), during quiz creation, query only questions ids, then query only questions picked for the quiz by their ids, instead of querying directly all questions and then pick some for the quiz.